### PR TITLE
Raw Markdown View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- switch between preview and raw markdown w/ right click
+
+### Changed
+- rich-markdown-editor dep upgraded (v11.22.0 --> v12.0.1)
+
+### Fixed
+- modals stay within container bounds
 
 ## [0.2.2] - 2022-07-23
 ### Changed

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.86",
     "@mui/material": "^5.8.4",
-    "@noted-md/rich-markdown-editor": "^11.22.0",
+    "@noted-md/rich-markdown-editor": "^12.0.1",
     "@reduxjs/toolkit": "^1.8.2",
     "custom-electron-titlebar": "^4.1.0",
     "electron-debug": "^3.2.0",

--- a/src/app/components/Modal/SettingsModal.jsx
+++ b/src/app/components/Modal/SettingsModal.jsx
@@ -48,46 +48,44 @@ const SettingsModal = ({ open, onClose, onSave }) => {
   };
 
   return (
-    <div>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
-        <DialogTitle>Settings</DialogTitle>
-        <DialogContent>
-          <TextField
-            value={notesDir}
-            autoFocus
-            margin="normal"
-            id="dir"
-            label="Notes Directory"
-            fullWidth
-            variant="outlined"
-            InputProps={{
-              readOnly: true,
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="select notes directory"
-                    onClick={fireSelectNotesDirEvent}
-                    edge="end"
-                    size="small"
-                    sx={{ p: 1 }}
-                  >
-                    <FolderOpen />
-                  </IconButton>
-                </InputAdornment>
-              )
-            }}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button variant="outlined" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button variant="outlined" onClick={onSave}>
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </div>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Settings</DialogTitle>
+      <DialogContent>
+        <TextField
+          value={notesDir}
+          autoFocus
+          margin="normal"
+          id="dir"
+          label="Notes Directory"
+          fullWidth
+          variant="outlined"
+          InputProps={{
+            readOnly: true,
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="select notes directory"
+                  onClick={fireSelectNotesDirEvent}
+                  edge="end"
+                  size="small"
+                  sx={{ p: 1 }}
+                >
+                  <FolderOpen />
+                </IconButton>
+              </InputAdornment>
+            )
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="outlined" onClick={onSave}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/src/app/components/Modal/TrashModal.jsx
+++ b/src/app/components/Modal/TrashModal.jsx
@@ -136,86 +136,91 @@ const TrashModal = ({ open, onClose }) => {
   }, [open, notes]);
 
   return (
-    <div>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
-        <DialogTitle>Trash</DialogTitle>
-        <DialogContent>
-          {Object.keys(trash).length === 0 && (
-            <DialogContentText display="flex" flexDirection="column">
-              <Typography variant="h6" fontSize="1.1em" component="span">
-                Empty
+    <Dialog
+      open={open}
+      onClose={onClose}
+      disablePortal
+      fullWidth
+      maxWidth="xs"
+      sx={{ position: 'absolute' }}
+    >
+      <DialogTitle>Trash</DialogTitle>
+      <DialogContent>
+        {Object.keys(trash).length === 0 && (
+          <DialogContentText display="flex" flexDirection="column">
+            <Typography variant="h6" fontSize="1.1em" component="span">
+              Empty
+            </Typography>
+            Items deleted via the context menu will appear here.
+          </DialogContentText>
+        )}
+
+        <TrashTree
+          initialTrash={trash}
+          selectedId={selected.id}
+          onSelect={handleTrashSelection}
+        />
+      </DialogContent>
+      <DialogActions disableSpacing sx={{ flexDirection: 'column' }}>
+        <TextField
+          id="dir"
+          label="Destination"
+          select
+          value={destDirId}
+          disabled={!selected.id}
+          onChange={({ target: { value } }) => setDestDirId(value)}
+          autoFocus
+          fullWidth
+          margin="normal"
+          SelectProps={{
+            IconComponent: FolderOpen,
+            renderValue: renderDestSelectValue,
+            MenuProps: {
+              MenuListProps: { dense: true },
+              PaperProps: { sx: { maxHeight: 320 } }
+            }
+          }}
+          sx={{
+            '& .MuiSelect-icon': {
+              right: '14px',
+              transform: 'none'
+            }
+          }}
+        >
+          {menuHeaderOptions.map(({ id, label, title }) => (
+            <MenuItem key={label} value={id}>
+              <Typography variant="button" mr={3} color="textSecondary">
+                {label}
               </Typography>
-              Items deleted via the context menu will appear here.
-            </DialogContentText>
-          )}
+              {title}
+            </MenuItem>
+          ))}
+          {menuHeaderOptions.length !== 0 && <Divider />}
+          {destOptionIds.map(renderDestOption)}
+        </TextField>
 
-          <TrashTree
-            initialTrash={trash}
-            selectedId={selected.id}
-            onSelect={handleTrashSelection}
-          />
-        </DialogContent>
-        <DialogActions disableSpacing sx={{ flexDirection: 'column' }}>
-          <TextField
-            id="dir"
-            label="Destination"
-            select
-            value={destDirId}
-            disabled={!selected.id}
-            onChange={({ target: { value } }) => setDestDirId(value)}
-            autoFocus
+        <Box display="flex" width="100%" gap={1}>
+          <Button
+            disabled={!selected.id || !destDirId}
+            variant="outlined"
+            color="success"
             fullWidth
-            margin="normal"
-            SelectProps={{
-              IconComponent: FolderOpen,
-              renderValue: renderDestSelectValue,
-              MenuProps: {
-                MenuListProps: { dense: true },
-                PaperProps: { sx: { maxHeight: 320 } }
-              }
-            }}
-            sx={{
-              '& .MuiSelect-icon': {
-                right: '14px',
-                transform: 'none'
-              }
-            }}
+            onClick={handleRestore}
           >
-            {menuHeaderOptions.map(({ id, label, title }) => (
-              <MenuItem key={label} value={id}>
-                <Typography variant="button" mr={3} color="textSecondary">
-                  {label}
-                </Typography>
-                {title}
-              </MenuItem>
-            ))}
-            {menuHeaderOptions.length !== 0 && <Divider />}
-            {destOptionIds.map(renderDestOption)}
-          </TextField>
-
-          <Box display="flex" width="100%" gap={1}>
-            <Button
-              disabled={!selected.id || !destDirId}
-              variant="outlined"
-              color="success"
-              fullWidth
-              onClick={handleRestore}
-            >
-              Restore
-            </Button>
-            <Button
-              disabled={!selected.id}
-              variant="outlined"
-              color="error"
-              fullWidth
-              onClick={handleDelete}
-            >
-              Delete
-            </Button>
-          </Box>
-        </DialogActions>
-      </Dialog>
-    </div>
+            Restore
+          </Button>
+          <Button
+            disabled={!selected.id}
+            variant="outlined"
+            color="error"
+            fullWidth
+            onClick={handleDelete}
+          >
+            Delete
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -66,6 +66,7 @@ export default function Index() {
   const selectedNoteId = useSelector((store) => store.selectedNoteId);
   const [initialValue, setInitialValue] = useState(unselectedInitialVal);
   const [modalType, setModalType] = useState();
+  const [raw, setRaw] = useState(false);
 
   const handleInputChange = (val) => {
     dispatch(saveNote(val()));
@@ -107,12 +108,14 @@ export default function Index() {
             />
             <StyledEditor
               dark
+              raw={raw}
               value={selectedNoteId ? initialValue : unselectedInitialVal}
               placeholder="# Title"
               readOnly={!selectedNoteId}
               dictionary={{ newLineEmpty: undefined }}
               colorTheme={editorColorTheme}
               onChange={debouncedSave}
+              onContextMenu={() => setRaw((prev) => !prev)}
               onBlur={() => setInitialValue('')}
             />
           </Box>

--- a/src/app/styles/theme.js
+++ b/src/app/styles/theme.js
@@ -39,7 +39,8 @@ export const editorColorTheme = {
   toolbarItem: primaryTextColor,
   toolbarItemSelected: selectedColor,
   tableDivider: borderColor,
-  quote: blueGrey[200]
+  quote: blueGrey[200],
+  markdownText: '#7693ba'
 };
 
 const darkTheme = createTheme({
@@ -92,6 +93,9 @@ const darkTheme = createTheme({
         .MuiPaper-rounded::-webkit-scrollbar-thumb,
         #block-menu-container::-webkit-scrollbar-thumb`]: {
           borderRadius: 4
+        },
+        '.MuiPaper-root, .MuiTypography-root, .MuiTabs-root': {
+          userSelect: 'none'
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,10 +932,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@noted-md/rich-markdown-editor@^11.22.0":
-  version "11.22.0"
-  resolved "https://registry.yarnpkg.com/@noted-md/rich-markdown-editor/-/rich-markdown-editor-11.22.0.tgz#d6e41a63bfd5b4de38ca85fbea71f69c51a10177"
-  integrity sha512-qIr92WBgOM8OMmAyBgcmnkOhqD87Ml0lZirt0Kj3FOswRyN6Q79OgITfaAZVuOm5O3tg672keradzwZtjeBQDg==
+"@noted-md/rich-markdown-editor@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@noted-md/rich-markdown-editor/-/rich-markdown-editor-12.0.1.tgz#32c970d7562f13a583b24cff30893a8fcd4bab83"
+  integrity sha512-INLXiMSc/OO7UumROIWwbVpRRkmGuzaxU1Q0Im81oLtwjfdHDzmXvAYKW+/thhxmRzowY963jnq/hnOncgaVwQ==
   dependencies:
     copy-to-clipboard "^3.0.8"
     fuzzy-search "^3.2.1"


### PR DESCRIPTION
* switch between preview and raw markdown w/ right click.
* rich-markdown-editor dep upgraded (v11.22.0 --> v12.0.1).
* modals stay within container bounds.
* labels are no longer selectable, to allow for ctrl+A in editor.